### PR TITLE
feat: Konami Code easter egg with synthwave theme

### DIFF
--- a/docs/plans/2026-02-22-konami-easter-egg-design.md
+++ b/docs/plans/2026-02-22-konami-easter-egg-design.md
@@ -1,0 +1,64 @@
+# Konami Code Easter Egg Design
+
+**Date:** 2026-02-22
+**Status:** Approved
+
+## Overview
+
+Add a Konami Code easter egg that toggles between the default cyan theme and a synthwave pink/purple theme.
+
+## User Experience
+
+1. User enters Konami Code: ↑↑↓↓←→←→BA
+2. Theme smoothly transitions to synthwave colors
+3. Theme persists in localStorage across sessions
+4. Entering the code again toggles back to default theme
+
+## Implementation Approach
+
+**CSS Variables Swap** - Add a `data-theme="synthwave"` attribute to `<html>` and define alternate CSS variable values. This integrates with the existing `--color-*` variable system.
+
+## Color Palette
+
+| Variable | Default (Cyan) | Synthwave |
+|----------|---------------|-----------|
+| `--color-neon-cyan` | `#00f5ff` | `#ff00ff` |
+| `--color-terminal-green` | `#00ff88` | `#ff66b2` |
+| `--color-terminal-prompt` | `#a855f7` | `#00ffff` |
+| `--color-bg-primary` | `#0a0a0f` | `#1a0a1f` |
+| `--color-bg-secondary` | `#12121a` | `#1f0a2a` |
+
+## Components
+
+### 1. useKonamiCode Hook
+- Listens for keydown events
+- Tracks key sequence against Konami Code pattern
+- Calls callback when sequence matches
+- Cleans up event listeners
+
+### 2. useTheme Hook
+- Reads/writes theme preference to localStorage
+- Applies `data-theme` attribute to document
+- Provides toggle function
+
+### 3. CSS Theme Definitions
+- Add `[data-theme="synthwave"]` selector block to index.css
+- Override color variables with synthwave palette
+- Add transition on `:root` for smooth color changes
+
+### 4. Integration
+- Initialize theme hooks in App.tsx or Layout.tsx
+- Connect Konami Code detection to theme toggle
+
+## Files to Create/Modify
+
+- `src/hooks/useKonamiCode.ts` - New hook
+- `src/hooks/useTheme.ts` - New hook
+- `src/index.css` - Add synthwave theme variables
+- `src/App.tsx` or `src/components/layout/Layout.tsx` - Wire up hooks
+
+## Testing
+
+- Manual: Enter Konami Code, verify theme changes
+- Verify localStorage persistence on refresh
+- Verify toggle works both directions

--- a/docs/plans/2026-02-22-konami-easter-egg.md
+++ b/docs/plans/2026-02-22-konami-easter-egg.md
@@ -1,0 +1,314 @@
+# Konami Code Easter Egg Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Konami Code easter egg that toggles between the default cyan theme and a synthwave pink/purple theme.
+
+**Architecture:** Two custom React hooks (`useKonamiCode` for key detection, `useTheme` for theme state/persistence) wired together in the Layout component. CSS variables swap via `data-theme` attribute on `<html>`.
+
+**Tech Stack:** React hooks, CSS custom properties, localStorage, TypeScript
+
+---
+
+## Task 1: Add Synthwave Theme CSS Variables
+
+**Files:**
+- Modify: `src/index.css:1-37`
+
+**Step 1: Add transition to :root for smooth color changes**
+
+Add after line 26 (after `@theme` block):
+
+```css
+:root {
+  transition: background-color 0.5s ease, color 0.5s ease;
+}
+
+* {
+  transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease, box-shadow 0.5s ease;
+}
+```
+
+**Step 2: Add synthwave theme override block**
+
+Add before the `body` rule (around line 28):
+
+```css
+[data-theme="synthwave"] {
+  --color-bg-primary: #1a0a1f;
+  --color-bg-secondary: #1f0a2a;
+  --color-bg-card: rgba(31, 10, 42, 0.8);
+  --color-neon-cyan: #ff00ff;
+  --color-neon-green: #ff66b2;
+  --color-neon-purple: #00ffff;
+  --color-terminal-green: #ff66b2;
+  --color-terminal-prompt: #00ffff;
+  --shadow-neon-cyan: 0 0 20px rgba(255, 0, 255, 0.3);
+  --shadow-neon-green: 0 0 20px rgba(255, 102, 178, 0.3);
+}
+```
+
+**Step 3: Verify manually**
+
+Open browser DevTools, add `data-theme="synthwave"` to `<html>` element, verify colors change smoothly.
+
+**Step 4: Commit**
+
+```bash
+git add src/index.css
+git commit -m "feat: add synthwave theme CSS variables"
+```
+
+---
+
+## Task 2: Create useKonamiCode Hook
+
+**Files:**
+- Create: `src/hooks/useKonamiCode.ts`
+
+**Step 1: Create the hook file**
+
+```typescript
+import { useEffect, useCallback, useRef } from 'react';
+
+const KONAMI_CODE = [
+  'ArrowUp',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowRight',
+  'KeyB',
+  'KeyA',
+];
+
+export function useKonamiCode(callback: () => void): void {
+  const inputRef = useRef<string[]>([]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      inputRef.current = [...inputRef.current, event.code].slice(-KONAMI_CODE.length);
+
+      if (inputRef.current.join(',') === KONAMI_CODE.join(',')) {
+        callback();
+        inputRef.current = [];
+      }
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}
+```
+
+**Step 2: Verify manually**
+
+Temporarily add to App.tsx:
+```typescript
+import { useKonamiCode } from './hooks/useKonamiCode';
+// In AppContent:
+useKonamiCode(() => console.log('Konami!'));
+```
+
+Test in browser - enter code, check console for "Konami!".
+
+**Step 3: Remove temporary test code**
+
+**Step 4: Commit**
+
+```bash
+git add src/hooks/useKonamiCode.ts
+git commit -m "feat: add useKonamiCode hook"
+```
+
+---
+
+## Task 3: Create useTheme Hook
+
+**Files:**
+- Create: `src/hooks/useTheme.ts`
+
+**Step 1: Create the hook file**
+
+```typescript
+import { useState, useEffect, useCallback } from 'react';
+
+type Theme = 'default' | 'synthwave';
+
+const THEME_STORAGE_KEY = 'wagner-theme';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'default';
+    return (localStorage.getItem(THEME_STORAGE_KEY) as Theme) || 'default';
+  });
+
+  useEffect(() => {
+    if (theme === 'synthwave') {
+      document.documentElement.setAttribute('data-theme', 'synthwave');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => (current === 'default' ? 'synthwave' : 'default'));
+  }, []);
+
+  return { theme, toggleTheme };
+}
+```
+
+**Step 2: Verify manually**
+
+Temporarily add to App.tsx:
+```typescript
+import { useTheme } from './hooks/useTheme';
+// In AppContent:
+const { toggleTheme } = useTheme();
+// Add button: <button onClick={toggleTheme}>Toggle</button>
+```
+
+Click button, verify theme changes. Refresh page, verify theme persists.
+
+**Step 3: Remove temporary test code**
+
+**Step 4: Commit**
+
+```bash
+git add src/hooks/useTheme.ts
+git commit -m "feat: add useTheme hook with localStorage persistence"
+```
+
+---
+
+## Task 4: Export Hooks from Index
+
+**Files:**
+- Create: `src/hooks/index.ts`
+
+**Step 1: Create barrel export file**
+
+```typescript
+export { useKonamiCode } from './useKonamiCode';
+export { useTheme } from './useTheme';
+export { useTypingAnimation } from './useTypingAnimation';
+export { useGitHubStats } from './useGitHubStats';
+export { useIntersectionObserver } from './useIntersectionObserver';
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/hooks/index.ts
+git commit -m "feat: add hooks barrel export"
+```
+
+---
+
+## Task 5: Wire Up Konami Code in Layout
+
+**Files:**
+- Modify: `src/components/layout/Layout.tsx`
+
+**Step 1: Read current Layout.tsx**
+
+Read the file to understand current structure.
+
+**Step 2: Add hook imports and wire up**
+
+Add to imports:
+```typescript
+import { useKonamiCode, useTheme } from '../../hooks';
+```
+
+Add inside Layout component (before return):
+```typescript
+const { toggleTheme } = useTheme();
+useKonamiCode(toggleTheme);
+```
+
+**Step 3: Verify manually**
+
+Run dev server, enter Konami Code (↑↑↓↓←→←→BA), verify theme toggles to synthwave. Enter again, verify it toggles back. Refresh, verify persistence.
+
+**Step 4: Commit**
+
+```bash
+git add src/components/layout/Layout.tsx
+git commit -m "feat: wire up Konami Code easter egg to toggle synthwave theme"
+```
+
+---
+
+## Task 6: Update HeroSection Import Path
+
+**Files:**
+- Modify: `src/components/sections/HeroSection.tsx:1`
+
+**Step 1: Update import to use barrel export**
+
+Change:
+```typescript
+import { useTypingAnimation } from '../../hooks/useTypingAnimation';
+```
+
+To:
+```typescript
+import { useTypingAnimation } from '../../hooks';
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/sections/HeroSection.tsx
+git commit -m "refactor: use hooks barrel export in HeroSection"
+```
+
+---
+
+## Task 7: Final Integration Test
+
+**Step 1: Run full verification**
+
+1. Start dev server: `npm run dev`
+2. Open browser to localhost
+3. Verify default cyan theme displays
+4. Enter Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
+5. Verify smooth transition to pink/purple synthwave theme
+6. Verify all sections look correct with new colors
+7. Refresh page - verify synthwave persists
+8. Enter Konami Code again - verify toggles back to default
+9. Refresh - verify default persists
+
+**Step 2: Run build to ensure no errors**
+
+```bash
+npm run build
+```
+
+**Step 3: Update CLAUDE_STATUS.md**
+
+Add easter egg to completed items, remove from pending if applicable.
+
+**Step 4: Final commit if any cleanup needed**
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Add synthwave CSS variables | `src/index.css` |
+| 2 | Create useKonamiCode hook | `src/hooks/useKonamiCode.ts` |
+| 3 | Create useTheme hook | `src/hooks/useTheme.ts` |
+| 4 | Create hooks barrel export | `src/hooks/index.ts` |
+| 5 | Wire up in Layout | `src/components/layout/Layout.tsx` |
+| 6 | Update HeroSection import | `src/components/sections/HeroSection.tsx` |
+| 7 | Integration test | Manual verification |

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -512,6 +513,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -552,6 +554,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2070,8 +2073,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2138,6 +2140,7 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2148,6 +2151,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2158,6 +2162,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2207,6 +2212,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2544,6 +2550,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2594,7 +2601,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2737,6 +2743,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3033,8 +3040,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",
@@ -3148,6 +3154,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3696,6 +3703,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -4109,7 +4117,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4320,6 +4327,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4347,6 +4355,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4379,7 +4388,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4395,7 +4403,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4418,6 +4425,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4427,6 +4435,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4455,8 +4464,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4880,6 +4888,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4976,6 +4985,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6087,6 +6097,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6275,6 +6286,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from 'react';
 import Navbar from './Navbar';
+import { useKonamiCode, useTheme } from '../../hooks';
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 export function Layout({ children }: LayoutProps) {
+  const { toggleTheme } = useTheme();
+  useKonamiCode(toggleTheme);
+
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]">
       <Navbar />

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { useTypingAnimation } from '../../hooks/useTypingAnimation';
+import { useTypingAnimation } from '../../hooks';
 
 const terminalLines = [
   { command: 'whoami', output: 'Devin Wagner' },

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useKonamiCode } from './useKonamiCode';
+export { useTheme } from './useTheme';
+export { useTypingAnimation } from './useTypingAnimation';
+export { useGitHubStats } from './useGitHubStats';
+export { useIntersectionObserver } from './useIntersectionObserver';

--- a/src/hooks/useKonamiCode.ts
+++ b/src/hooks/useKonamiCode.ts
@@ -1,0 +1,35 @@
+import { useEffect, useCallback, useRef } from 'react';
+
+const KONAMI_CODE = [
+  'ArrowUp',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowRight',
+  'KeyB',
+  'KeyA',
+];
+
+export function useKonamiCode(callback: () => void): void {
+  const inputRef = useRef<string[]>([]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      inputRef.current = [...inputRef.current, event.code].slice(-KONAMI_CODE.length);
+
+      if (inputRef.current.join(',') === KONAMI_CODE.join(',')) {
+        callback();
+        inputRef.current = [];
+      }
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect, useCallback } from 'react';
+
+type Theme = 'default' | 'synthwave';
+
+const THEME_STORAGE_KEY = 'wagner-theme';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'default';
+    try {
+      const stored = localStorage.getItem(THEME_STORAGE_KEY);
+      return (stored === 'default' || stored === 'synthwave') ? stored : 'default';
+    } catch {
+      return 'default';
+    }
+  });
+
+  useEffect(() => {
+    if (theme === 'synthwave') {
+      document.documentElement.setAttribute('data-theme', 'synthwave');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Silent fail - theme still works in-memory
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => (current === 'default' ? 'synthwave' : 'default'));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,27 @@
   --shadow-neon-green: 0 0 20px rgba(57, 255, 20, 0.3);
 }
 
+:root {
+  transition: background-color 0.5s ease, color 0.5s ease;
+}
+
+* {
+  transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease, box-shadow 0.5s ease;
+}
+
+[data-theme="synthwave"] {
+  --color-bg-primary: #1a0a1f;
+  --color-bg-secondary: #1f0a2a;
+  --color-bg-card: rgba(31, 10, 42, 0.8);
+  --color-neon-cyan: #ff00ff;
+  --color-neon-green: #ff66b2;
+  --color-neon-purple: #00ffff;
+  --color-terminal-green: #ff66b2;
+  --color-terminal-prompt: #00ffff;
+  --shadow-neon-cyan: 0 0 20px rgba(255, 0, 255, 0.3);
+  --shadow-neon-green: 0 0 20px rgba(255, 102, 178, 0.3);
+}
+
 /* Base dark background */
 body {
   background-color: var(--color-bg-primary);


### PR DESCRIPTION
## Summary

- Adds a Konami Code easter egg (↑↑↓↓←→←→BA) that toggles a synthwave pink/purple theme
- Theme persists in localStorage across sessions
- Smooth CSS transition between themes

## Changes

- **New hooks:**
  - `useKonamiCode` - Detects Konami Code key sequence
  - `useTheme` - Manages theme state with localStorage persistence
- **CSS:** Added `[data-theme="synthwave"]` variables for alternate color scheme
- **Layout:** Wired up hooks in Layout component

## Test plan

- [ ] Run `npm run dev`
- [ ] Enter Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
- [ ] Verify theme transitions smoothly to pink/purple
- [ ] Refresh page - verify theme persists
- [ ] Enter code again - verify toggles back to cyan
- [ ] Refresh - verify default persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)