### PR TITLE
feat: add About section with bio

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -56,6 +56,7 @@ export default function Navbar() {
   );
 
   const navLinks = [
+    { label: 'About', action: () => handleNavClick('about') },
     { label: 'Skills', action: () => handleNavClick('skills') },
     { label: 'Experience', action: () => handleNavClick('experience') },
     { label: 'GitHub', action: () => handleNavClick('github') },

--- a/src/components/sections/AboutSection.test.tsx
+++ b/src/components/sections/AboutSection.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AboutSection } from './AboutSection';
+
+describe('AboutSection', () => {
+  it('should render the section heading', () => {
+    render(<AboutSection />);
+    expect(screen.getByText('about_me')).toBeInTheDocument();
+  });
+
+  it('should render the greeting', () => {
+    render(<AboutSection />);
+    expect(screen.getByText("Hey, I'm Devin.")).toBeInTheDocument();
+  });
+
+  it('should render bio paragraphs', () => {
+    render(<AboutSection />);
+    expect(screen.getByText(/Senior Software Engineer based in Denver/)).toBeInTheDocument();
+    expect(screen.getByText(/exploring Colorado's trails/)).toBeInTheDocument();
+  });
+
+  it('should render the terminal command', () => {
+    render(<AboutSection />);
+    expect(screen.getByText('cat about.md')).toBeInTheDocument();
+  });
+
+  it('should have the about section id', () => {
+    const { container } = render(<AboutSection />);
+    expect(container.querySelector('#about')).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,0 +1,47 @@
+import { SectionHeading } from '../ui';
+import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
+import { aboutBio } from '../../data/content';
+
+export function AboutSection() {
+  const { ref, isVisible } = useIntersectionObserver(0.2);
+
+  return (
+    <section id="about" className="py-12 sm:py-16 md:py-24 px-4 sm:px-6" ref={ref}>
+      <div className="max-w-4xl mx-auto">
+        <SectionHeading>about_me</SectionHeading>
+
+        <div
+          className={`
+            bg-[var(--color-bg-card)]
+            backdrop-blur-sm
+            border border-[var(--color-neon-cyan)]/20
+            rounded-lg
+            p-6 sm:p-8
+            transition-all duration-700
+            ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}
+          `}
+        >
+          <div className="font-mono text-sm sm:text-base leading-relaxed">
+            <div className="flex items-center gap-2 mb-4">
+              <span className="text-[var(--color-terminal-prompt)]">$</span>
+              <span className="text-[var(--color-text-primary)]">cat about.md</span>
+            </div>
+
+            <p className="text-[var(--color-neon-cyan)] text-lg sm:text-xl font-semibold mb-4 ml-3 sm:ml-4">
+              {aboutBio.greeting}
+            </p>
+
+            {aboutBio.paragraphs.map((paragraph, index) => (
+              <p
+                key={index}
+                className="text-[var(--color-text-secondary)] mb-4 last:mb-0 ml-3 sm:ml-4"
+              >
+                {paragraph}
+              </p>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,3 +1,4 @@
+export { AboutSection } from './AboutSection';
 export { HeroSection } from './HeroSection';
 export { SkillsSection } from './SkillsSection';
 export { ExperienceSection } from './ExperienceSection';

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -19,6 +19,14 @@ export const terminalLines: TerminalLine[] = [
   { command: 'cat status.txt', output: 'Building great software in Denver, CO' },
 ];
 
+export const aboutBio = {
+  greeting: "Hey, I'm Devin.",
+  paragraphs: [
+    "I'm a Senior Software Engineer based in Denver, CO with a passion for building clean, scalable software. I've spent my career working across the full stack — from designing APIs with C# and .NET to crafting responsive UIs with Angular and React.",
+    "I thrive in collaborative environments where I can solve complex problems, mentor teammates, and continuously learn. When I'm not writing code, you'll probably find me exploring Colorado's trails and campgrounds.",
+  ],
+};
+
 export const skills = [
   { name: 'C#', category: 'backend' as const },
   { name: '.NET', category: 'backend' as const },

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -6,6 +6,7 @@ import HomePage from './HomePage';
 
 // Mock all section components to isolate HomePage test
 vi.mock('../components/sections', () => ({
+  AboutSection: () => <div data-testid="about-section">AboutSection</div>,
   HeroSection: () => <div data-testid="hero-section">HeroSection</div>,
   SkillsSection: () => <div data-testid="skills-section">SkillsSection</div>,
   ExperienceSection: () => <div data-testid="experience-section">ExperienceSection</div>,
@@ -32,6 +33,7 @@ describe('HomePage', () => {
     renderHomePage();
 
     expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+    expect(screen.getByTestId('about-section')).toBeInTheDocument();
     expect(screen.getByTestId('skills-section')).toBeInTheDocument();
     expect(screen.getByTestId('experience-section')).toBeInTheDocument();
     expect(screen.getByTestId('github-section')).toBeInTheDocument();
@@ -46,6 +48,7 @@ describe('HomePage', () => {
 
     expect(order).toEqual([
       'hero-section',
+      'about-section',
       'skills-section',
       'experience-section',
       'github-section',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
+  AboutSection,
   HeroSection,
   SkillsSection,
   ExperienceSection,
@@ -22,6 +23,7 @@ export default function HomePage() {
   return (
     <>
       <HeroSection />
+      <AboutSection />
       <SkillsSection />
       <ExperienceSection />
       <GitHubSection />


### PR DESCRIPTION
## Summary
- Adds a new About section between Hero and Skills with terminal-themed styling (`cat about.md`)
- Adds "About" nav link to the navbar (desktop + mobile)
- Bio content stored in `data/content.ts` for easy editing
- Includes 5 unit tests for the new component and updated HomePage tests

## Test plan
- [x] Unit tests pass (222 → 227 tests)
- [x] Build succeeds with no type errors
- [ ] E2E tests pass in CI (couldn't run locally — Playwright browsers not available in environment)
- [ ] Verify About section renders between Hero and Skills on homepage
- [ ] Verify "About" navbar link scrolls to the section

https://claude.ai/code/session_01G5nuQqm73PCypoN6p3agnn